### PR TITLE
Dynamic parametrisation

### DIFF
--- a/Local-user/test_local_user_login.py
+++ b/Local-user/test_local_user_login.py
@@ -1,12 +1,9 @@
 """Note: as all tests are executed from root user, first login to any user
 do not require any credentials!
 """
-import pytest
 from SCAutolib.models.authselect import Authselect
-from SCAutolib.utils import user_factory
 
 
-@pytest.mark.parametrize("user", [user_factory("local-user")], scope="session")
 def test_su_login_with_sc(user, user_shell):
     """Basic su login to the user with a smart card.
 
@@ -50,7 +47,6 @@ def test_su_login_with_sc(user, user_shell):
             user_shell.expect_exact(user.username)
 
 
-@pytest.mark.parametrize("user", [user_factory("local-user")], scope="session")
 def test_su_login_with_sc_wrong(user, user_shell):
     """Basic su login to the user with a smartcard when user inters wrong PIN.
 
@@ -93,7 +89,6 @@ def test_su_login_with_sc_wrong(user, user_shell):
             user_shell.expect(f"su: Authentication failure")
 
 
-@pytest.mark.parametrize("user", [user_factory("local-user")], scope="session")
 def test_gdm_login_sc_required(user, root_shell):
     """GDM login to the user when smart card is required. Point is to check
     that GDM prompts to insert the smart card if it is not inserted
@@ -140,7 +135,6 @@ def test_gdm_login_sc_required(user, root_shell):
             root_shell.expect("pam_authenticate.*Success")
 
 
-@pytest.mark.parametrize("user", [user_factory("local-user")], scope="session")
 def test_su_login_without_sc(user, user_shell):
     """SU login with user password, smartcard is not required.
 
@@ -179,7 +173,6 @@ def test_su_login_without_sc(user, user_shell):
         user_shell.expect_exact(user.username)
 
 
-@pytest.mark.parametrize("user", [user_factory("local-user")], scope="session")
 def test_su_to_root(user, user_shell, root_user):
     """Test for smartcard login to the local user and then switching to root (su -).
 

--- a/Sanity/test_smart_card_detection.py
+++ b/Sanity/test_smart_card_detection.py
@@ -1,46 +1,40 @@
 import pytest
 
-from fixtures import user_indirect, root_shell, edit_config
-from SCAutolib.src import virt_card, utils
 
-
-def test_modutil_token_info(user, root_shell):
+def test_modutil_token_info(local_user, root_shell):
     """Check that p11-kit module shows smart card information with modutil
     command"""
     cmd = "modutil -list -dbdir /etc/pki/nssdb"
-    uri = f"pkcs11:token={user.USERNAME_LOCAL};manufacturer=Common%20Access" \
+    uri = f"pkcs11:token={local_user.username};manufacturer=Common%20Access" \
           f"%20Card;serial=000058bd002c19b5;model=PKCS%2315%20emulated"
-    with virt_card.VirtCard(user.USERNAME_LOCAL, insert=True):
+    with local_user.card(insert=True):
         root_shell.sendline(cmd)
         root_shell.expect_exact(uri)
 
 
-@pytest.mark.parametrize("file_path,target,restore,restart",
-                         [("/etc/sssd/sssd.conf",
-                           ({"section": "pam",
-                             "key": "pam_p11_allowed_services",
-                             "val": "-su"}), True, ["sssd"])])
-def test_pam_services_config(user, root_shell, edit_config):
+def test_pam_services_config(local_user, root_shell, sssd):
     """Test for PAM configuration for smart card authentication.
     GitHub issue: https://github.com/SSSD/sssd/issues/3967"""
     with open("/etc/pam.d/pam_cert_service", "w") as f:
         f.write("auth\trequired\tpam_sss.so require_cert_auth")
-    with virt_card.VirtCard(user.USERNAME_LOCAL, insert=True):
-        cmd = "sssctl user-checks -a auth -s pam_cert_service " \
-              f"{user.USERNAME_LOCAL}"
-        root_shell.sendline(cmd)
-        fail = f"pam_authenticate for user [{user.USERNAME_LOCAL}]: " \
-               "Authentication service cannot retrieve authentication info"
-        root_shell.expect_exact("Please insert smart card")
-        root_shell.expect_exact("Password:")
-        root_shell.sendline(user.PASSWD_LOCAL)
-        root_shell.expect_exact(fail)
+    with sssd(section="pam", key="pam_p11_allowed_services", value="-su") as sssd_conf:
+        with local_user.card(insert=True):
+            cmd = "sssctl user-checks -a auth -s pam_cert_service " \
+                  f"{local_user.username}"
+            root_shell.sendline(cmd)
+            fail = f"pam_authenticate for user [{local_user.username}]: " \
+                   "Authentication service cannot retrieve authentication info"
+            root_shell.expect_exact("Please insert smart card")
+            root_shell.expect_exact("Password:")
+            root_shell.sendline(local_user.password)
+            root_shell.expect_exact(fail)
 
-        utils.edit_config_("/etc/sssd/sssd.conf", "pam",
-                           "pam_p11_allowed_services", "+pam_cert_service")
-        utils.restart_service("sssd")
+            sssd_conf(section="pam",
+                      key="pam_p11_allowed_services",
+                      value="+pam_cert_service")
 
-        root_shell.sendline(cmd)
-        root_shell.expect_exact(f"PIN for {user.USERNAME_LOCAL}:")
-        root_shell.sendline(user.PIN_LOCAL)
-        root_shell.expect_exact(f"pam_authenticate for user [{user.USERNAME_LOCAL}]: Success")
+            root_shell.sendline(cmd)
+            root_shell.expect_exact(f"PIN for {local_user.username}:")
+            root_shell.sendline(local_user.pin)
+            root_shell.expect_exact(f"pam_authenticate for user "
+                                    f"[{local_user.username}]: Success")

--- a/Sanity/test_ttylogin.py
+++ b/Sanity/test_ttylogin.py
@@ -10,9 +10,8 @@ does it is good approximation to manual testing in virtual console.
 import sys
 
 import pexpect
-import pytest
+
 from SCAutolib.models.authselect import Authselect
-from SCAutolib.utils import user_factory, ipa_factory
 
 
 def login_shell_factory(username):
@@ -23,10 +22,6 @@ def login_shell_factory(username):
     return shell
 
 
-@pytest.mark.parametrize("user", [user_factory("local-user"),
-                                  user_factory("rhel-86-regression",
-                                               ipa_server=ipa_factory())],
-                         scope="session")
 def test_login_with_sc(user):
     """Console-like login to the user with a smart card.
     Setup
@@ -63,10 +58,6 @@ def test_login_with_sc(user):
             login_shell.sendline("exit")
 
 
-@pytest.mark.parametrize("user", [user_factory("local-user"),
-                                  user_factory("rhel-86-regression",
-                                               ipa_server=ipa_factory())],
-                         scope="session")
 def test_login_without_sc(user):
     """Console-like login to the user without a smart card.
     Setup
@@ -100,10 +91,6 @@ def test_login_without_sc(user):
         login_shell.expect(user.username)
 
 
-@pytest.mark.parametrize("user", [user_factory("local-user"),
-                                  user_factory("rhel-86-regression",
-                                               ipa_server=ipa_factory())],
-                         scope="session")
 def test_login_with_sc_required(user):
     """Console-like login to the user with a smart card; smartcard required.
     Setup

--- a/conftest.py
+++ b/conftest.py
@@ -6,13 +6,6 @@ log = logging.getLogger("PyTest")
 log.setLevel(logging.DEBUG)
 
 
-def pytest_configure():
-    """
-    This function add global variables to the test session
-    """
-    pytest.ipa_server = ipa_factory()
-
-
 def pytest_addoption(parser):
     """
     Specification of CLI options.
@@ -60,14 +53,18 @@ def pytest_generate_tests(metafunc):
     user type by adding `local_user` argmunet inseted of `user` argument.
     Similar is true for `ipa_user` argument.
     """
+    user_type = metafunc.config.getoption("user_type")
+    if user_type == "ipa":
+        pytest.ipa_server = ipa_factory()
+
     if 'user' in metafunc.fixturenames:
         users = []
-        if metafunc.config.getoption("user_type") in ["local", "all"]:
+        if user_type in ["local", "all"]:
             u = user_factory(metafunc.config.getoption("local_username"))
             assert u.local
             users.append(u)
 
-        if metafunc.config.getoption("user_type") in ["ipa", "all"]:
+        if user_type in ["ipa", "all"]:
             u = user_factory(metafunc.config.getoption("ipa_username"), ipa_server=pytest.ipa_server)
             assert not u.local
             users.append(u)

--- a/conftest.py
+++ b/conftest.py
@@ -1,1 +1,83 @@
 from fixtures import *
+from SCAutolib.utils import user_factory, ipa_factory
+import logging
+
+log = logging.getLogger("PyTest")
+log.setLevel(logging.DEBUG)
+
+
+def pytest_configure():
+    """
+    This function add global variables to the test session
+    """
+    pytest.ipa_server = ipa_factory()
+
+
+def pytest_addoption(parser):
+    """
+    Specification of CLI options.
+    """
+    parser.addoption(
+        "--ipa-username",
+        action="store",
+        default='ipa-user',
+        help="Username of IPA user to be used in tests",
+        dest="ipa_username"
+    )
+    parser.addoption(
+        "--local-username",
+        action="store",
+        default='local-user',
+        help="Username of local user to be used in tests",
+        dest="local_username"
+    )
+    parser.addoption(
+        "--with-user-type",
+        action="store",
+        default='local',
+        dest="user_type",
+        help="Type of user to be used in tests",
+        choices=['local', 'ipa', 'all']
+    )
+
+
+def pytest_generate_tests(metafunc):
+    """
+    This function would set 'user' argument in test (if present) for users that
+    we want to test.
+
+    For example, if we want to execute the test only with local user, we
+    need to se `--with-user-type local` in pytest command. Defualt name for
+    local user is "local-user". If the system is configured to a user with
+    different name, set this name with `--local-username NAME` option.
+    Similar options are available for IPA user. If we want to test with both,
+    use `--with-user-type all`. This would set 'user' argument to both local
+    and IPA user using names specified by `--local-username` and `--ipa-username`
+    (or default names if not specified).
+
+    To avoid execuing test that are not relevant for the user type (e.g. test
+    that is relevant only for local user), this test has to specify expicitly
+    user type by adding `local_user` argmunet inseted of `user` argument.
+    Similar is true for `ipa_user` argument.
+    """
+    if 'user' in metafunc.fixturenames:
+        users = []
+        if metafunc.config.getoption("user_type") in ["local", "all"]:
+            u = user_factory(metafunc.config.getoption("local_username"))
+            assert u.local
+            users.append(u)
+
+        if metafunc.config.getoption("user_type") in ["ipa", "all"]:
+            u = user_factory(metafunc.config.getoption("ipa_username"), ipa_server=pytest.ipa_server)
+            assert not u.local
+            users.append(u)
+
+        metafunc.parametrize("user", users)
+    elif 'ipa_user' in metafunc.fixturenames:
+        u = user_factory(metafunc.config.getoption("ipa_username"), ipa_server=pytest.ipa_server)
+        assert not u.local
+        metafunc.parametrize("ipa_user", [u])
+    elif 'local_user' in metafunc.fixturenames:
+        u = user_factory(metafunc.config.getoption("local_username"))
+        assert u.local
+        metafunc.parametrize("local_user", [u])

--- a/fixtures.py
+++ b/fixtures.py
@@ -27,6 +27,6 @@ def root_user():
     return user_factory("root")
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def sssd():
     return SSSDConf()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pytest>=7.1.2
-pexpect>=4.8.0
+pytest>=7
+pexpect>=4


### PR DESCRIPTION
This PR shows how to use dynamic parameterization for test.
Example of pytest execution

```bash
pytest Local-user/test_local_user_login.py --with-user-type local --local-username local-user
```
How it works internally check pytest [documentation](https://docs.pytest.org/en/6.2.x/parametrize.html#basic-pytest-generate-tests-example) and the source code in `conftest.py`