### PR TITLE
Fixed test, that forgot to close login shell

### DIFF
--- a/Sanity/test_ttylogin.py
+++ b/Sanity/test_ttylogin.py
@@ -89,6 +89,7 @@ def test_login_without_sc(user):
         login_shell.expect(f"Password:")
         login_shell.sendline(user.password)
         login_shell.expect(user.username)
+        login_shell.sendline("exit")
 
 
 def test_login_with_sc_required(user):


### PR DESCRIPTION
One of tests in test_ttylogin.py did not close the login shell, which it has previously opened. Sometimes, this caused the next test to fail.