### PR TITLE
Added graphical tests

### DIFF
--- a/Graphical/local-user-graphical-login.py
+++ b/Graphical/local-user-graphical-login.py
@@ -1,0 +1,202 @@
+"""
+This module contains tests for logging into GUI using GDM.
+Most of the tests are parametrized to test both
+optional and required smart card in authselect.
+Lock-on-removal option is not set as it is irelevent for present tests.
+The tests within the module try logging in both using password and
+smart card with PIN. Both wrong password and wrong PIN are tested too.
+All tests depend on SCAutolib GUI module.
+
+If not stated otherwise tests in this module use virtual cards
+and share the following setup steps:
+    1. Create local CA
+    2. Create virtual smart card with certs signed by created CA
+    3. Update /etc/sssd/sssd.conf so it contains following fields
+        [sssd]
+        debug_level = 9
+        services = nss, pam,
+        domains = shadowutils
+        certificate_verification = no_ocsp
+        [pam]
+        debug_level = 9
+        pam_cert_auth = True
+        [domain/shadowutils]
+        debug_level = 9
+        id_provider = files
+        [certmap/shadowutils/username]
+        matchrule = <SUBJECT>.*CN=username.*
+"""
+
+from SCAutolib.models.authselect import Authselect
+from SCAutolib.models.gui import GUI
+from SCAutolib.models.log import assert_log
+import pytest
+from time import sleep
+
+SECURE_LOG = '/var/log/secure'
+
+
+@pytest.mark.parametrize("required", [(True), (False)])
+def test_login_with_sc(local_user, required):
+    """Local user logs in with GDM, using smart card with correct PIN.
+
+    Test steps
+        A. Configure SSSD:
+            authselect select sssd with-smartcard
+            OR
+            authselect select sssd with-smartcard with-smartcard-required
+        B. Start GDM
+        C. Insert the card and type the correct PIN
+
+    Expected result
+        A. Configuration is updated
+        B. GDM starts successfully
+        C. User is asked for smartcard PIN and
+            logged into GNOME desktop environment successfully
+    """
+    expected_log = (
+        r'.* localhost gdm-smartcard\]\[[0-9]+\]: '
+        r'pam_sss\(gdm-smartcard:auth\): authentication success;'
+        r'.*user=' + local_user.username + r'@shadowutils.*'
+    )
+
+    with Authselect(required=required), local_user.card(insert=True), GUI() as gui:
+        gui.assert_text('PIN')
+        gui.kb_write(local_user.pin)
+
+        with assert_log(SECURE_LOG, expected_log):
+            gui.kb_send('enter', wait_time=10)
+        # Mandatory wait to switch display from GDM to GNOME
+        # Not waiting can actually mess up the output
+        gui.assert_text('Activities')
+
+
+@pytest.mark.parametrize("required", [(True), (False)])
+def test_login_with_sc_wrong(local_user, required):
+    """Local user tries to log in with GDM, using smart card with wrong PIN.
+
+    Test steps
+        A. Configure SSSD:
+            authselect select sssd with-smartcard
+            OR
+            authselect select sssd with-smartcard with-smartcard-required
+        B. Start GDM
+        C. Insert the card and type an incorrect PIN
+
+    Expected result
+        A. Configuration is updated
+        B. GDM starts successfully
+        C. A message about incorrect PIN is displayed and user is not logged in.
+    """
+    expected_log = (
+        r'.* localhost gdm-smartcard\]\[[0-9]+\]: '
+        r'pam_sss\(gdm-smartcard:auth\): authentication failure;'
+        r'.*user=' + local_user.username + r'@shadowutils.*'
+    )
+
+    with Authselect(required=required), local_user.card(insert=True), GUI() as gui:
+        gui.assert_text('PIN')
+        gui.kb_write(local_user.pin[:-1])
+
+        with assert_log(SECURE_LOG, expected_log):
+            gui.kb_send('enter', wait_time=10)
+        # Mandatory wait to switch display from GDM to GNOME
+        # Not waiting can actually mess up the output
+        gui.assert_no_text('Activities')
+        gui.assert_text('PIN')
+
+
+def test_login_password(local_user):
+    """Local user logs in with GDM using his password.
+
+    Test steps
+        A. Configure SSSD:
+            authselect select sssd with-smartcard
+        B. Start GDM
+        C. Login as the user in GDM using password
+
+    Expected result
+        A. Configuration is updated
+        B. GDM starts successfully
+        C. User is successfully logged into GNOME desktop environment
+    """
+    expected_log = (
+        r'.* pam_unix\(gdm-password:session\): session opened for user .*'
+        )
+
+    with Authselect(required=False), GUI() as gui:
+        gui.click_on(local_user.username)
+        gui.kb_write(local_user.password)
+        with assert_log(SECURE_LOG, expected_log):
+            gui.kb_send('enter', wait_time=10)
+        gui.assert_text('Activities')
+
+
+def test_login_password_wrong(local_user):
+    """Local user tries to log in with GDM using incorrect password.
+
+    Test steps
+        A. Configure SSSD:
+            authselect select sssd with-smartcard
+        B. Start GDM
+        C. Try to log in using wrong password
+
+    Expected result
+        A. Configuration is updated
+        B. GDM starts successfully
+        C. A message about incorrect password is displayed
+            and login is unsuccessful.
+    """
+    expected_log = (
+        r'.* localhost gdm-password\]\[[0-9]+\]: '
+        r'pam_unix\(gdm-password:auth\): authentication failure;'
+        r'.*user=' + local_user.username + r'.*'
+    )
+
+    with Authselect(required=False), GUI() as gui:
+        gui.click_on(local_user.username)
+        gui.kb_write(local_user.password[:-1])
+        with assert_log(SECURE_LOG, expected_log):
+            gui.kb_send('enter', wait_time=10)
+
+        gui.assert_no_text('Activities')
+        gui.assert_text('Password')
+
+
+def test_insert_card_prompt(local_user):
+    """Local user tries to log in with GDM before inserting card,
+        with sc required.
+
+        Test steps
+        A. Configure SSSD:
+            authselect select sssd with-smartcard
+        B. Start GDM
+        C. Insert the smart card
+        D. Type the card's PIN
+
+    Expected result
+        A. Configuration is updated
+        B. GDM starts successfully and "insert card" message is displayed
+        C. GDM shows "insert PIN" prompt
+        D. User is logged in successfully.
+    """
+    with (Authselect(required=True),
+          local_user.card(insert=False) as card,
+          GUI() as gui):
+        gui.assert_text('insert')
+        card.insert()
+        sleep(10)
+        gui.assert_text('PIN')
+        gui.kb_write(local_user.pin)
+
+        expected_log = (
+            r'.* localhost gdm-smartcard\]\[[0-9]+\]: '
+            r'pam_sss\(gdm-smartcard:auth\): authentication success;'
+            r'.*user=' + local_user.username + r'@shadowutils.*'
+        )
+
+        with assert_log(SECURE_LOG, expected_log):
+            gui.kb_send('enter', wait_time=10)
+        # Mandatory wait to switch display from GDM to GNOME
+        # Not waiting can actually mess up the output
+        gui.assert_text('Activities')

--- a/Graphical/local-user-lock-on-removal.py
+++ b/Graphical/local-user-lock-on-removal.py
@@ -1,0 +1,165 @@
+"""
+This module contains tests for lock on removal feature
+of GNOME desktop environment.
+Most of the tests are parametrized to test both
+optional and required smart card in authselect.
+All tests depend on SCAutolib GUI module.
+
+If not stated otherwise tests in this module use virtual cards
+and share the following setup steps:
+    1. Create local CA
+    2. Create virtual smart card with certs signed by created CA
+    3. Update /etc/sssd/sssd.conf so it contains following fields
+        [sssd]
+        debug_level = 9
+        services = nss, pam,
+        domains = shadowutils
+        certificate_verification = no_ocsp
+        [pam]
+        debug_level = 9
+        pam_cert_auth = True
+        [domain/shadowutils]
+        debug_level = 9
+        id_provider = files
+        [certmap/shadowutils/username]
+        matchrule = <SUBJECT>.*CN=username.*
+"""
+
+from SCAutolib.models.authselect import Authselect
+from SCAutolib.models.gui import GUI
+from time import sleep
+import pytest
+
+
+@pytest.mark.parametrize("required", [(True), (False)])
+def test_lock_on_removal(local_user, required):
+    """Local user removes the card while logged in to lock the screen.
+
+    Test steps
+        A. Configure SSSD:
+            authselect select sssd with-smartcard
+            with-smartcard-lock-on-removal [with-smartcard-required]
+        B. Start GDM and insert PIN to log in
+        C. Remove the smart card
+        D. Wake up the system by pressing enter key
+            and unlock screen using PIN
+
+    Expected result
+        A. Configuration is updated
+        B. GDM starts and user logs in successfully
+        C. The system locks itself after the card is removed
+        D. The system is unlocked
+    """
+
+    with Authselect(required=required, lock_on_removal=True), GUI() as gui:
+        # insert the card and sign in a standard way
+        with local_user.card(insert=True) as card:
+            sleep(5)
+            gui.assert_text('PIN')
+            gui.kb_write(local_user.pin)
+            gui.kb_send('enter', wait_time=10)
+            # confirm that you are logged in
+            gui.assert_text('Activities')
+
+            # remove the card and wait for the screen to lock
+            card.remove()
+            sleep(5)
+            # Locking the screen in GNOME apparently does not generate any log.
+            # This could be checked by monitoring D-Bus signals
+
+            # Wake up the black screen by pressing enter
+            gui.kb_send('enter', screenshot=False)
+            # Confirm that the screen is locked
+            # After the screen has been locked, there should be no Activities
+            gui.assert_no_text('Activities')
+            gui.assert_text('insert')
+
+            card.insert()
+            # click on the password field
+            gui.click_on('PIN')
+            gui.kb_write(local_user.pin)
+            gui.kb_send('enter', wait_time=10)
+            # confirm that you are logged back in
+            gui.assert_text('Activities')
+
+
+def test_lock_on_removal_password(local_user):
+    """Local user inserts and removes the card while logged in with password.
+
+    Test steps
+        A. Configure SSSD:
+            authselect select sssd with-smartcard
+            with-smartcard-lock-on-removal
+        B. Start GDM and insert password to log in
+        C. Insert the smart card
+        D. Remove the smart card
+
+    Expected result
+        A. Configuration is updated
+        B. GDM starts and user logs in successfully
+        C. Nothing happens
+        D. Nothing happens - system will not lock on card removal
+    """
+    with Authselect(required=False, lock_on_removal=True), GUI() as gui:
+        with local_user.card(insert=False) as card:
+            gui.click_on(local_user.username)
+            gui.kb_write(local_user.password)
+            gui.kb_send('enter', wait_time=10)
+            gui.assert_text('Activities')
+
+            card.insert()
+            sleep(10)
+            card.remove()
+            sleep(10)
+
+            # Screen should be unlocked
+            gui.assert_text('Activities')
+
+
+@pytest.mark.parametrize("lock_on_removal", [(True), (False)])
+def test_lockscreen_password(local_user, lock_on_removal):
+    """Local user unlocks screen using password, even if the smart card is
+        inserted (after the password login). Screen unlocking requires the same
+        method (PIN vs password) as was used for login.
+
+    Test steps
+        A. Configure SSSD:
+            authselect select sssd with-smartcard
+            with-smartcard-lock-on-removal
+        B. Start GDM and insert password to log in
+        C. Insert the smart card
+        D. Lock the screen manually
+        E. Wake up and unlock the screen using password
+
+    Expected result
+        A. Configuration is updated
+        B. GDM starts and user logs in successfully
+        C. Nothing happens
+        D. The screen is locked
+        E. Screen is unlocked succesfully
+    """
+    with (
+        Authselect(required=False, lock_on_removal=lock_on_removal),
+        GUI() as gui,
+        local_user.card(insert=False) as card
+            ):
+        gui.click_on(local_user.username)
+        gui.kb_write(local_user.password)
+        gui.kb_send('enter', wait_time=10)
+        gui.assert_text('Activities')
+
+        card.insert()
+        sleep(10)
+        # press shortcut to lock the screen
+        gui.kb_send('windows+l', wait_time=5, screenshot=False)
+
+        # Wake up the black screen by pressing enter
+        gui.kb_send('enter', screenshot=False)
+        # Confirm that the screen is locked
+        # After the screen has been locked, there should be no Activities
+        gui.assert_no_text('Activities')
+        gui.click_on('Password', check_difference=False)
+        gui.kb_write(local_user.password)
+        gui.kb_send('enter', wait_time=10)
+        # confirm that you are logged back in
+        gui.assert_text('Activities')


### PR DESCRIPTION
Added support for testing the GDM login screen. The only important file is the python script, others are just placeholders. The test uses ffmpeg to get the screenshot, opencv to process it. Then the screenshot is converted to text using pyteserract. The test interacts with the SUT using uinput (for mouse) and keyboard libraries.