### PR TITLE
Fixing test_krb_user_sudo_correct_password_sc_required_no_sc

### DIFF
--- a/Kerberos/test_login_kerberos.py
+++ b/Kerberos/test_login_kerberos.py
@@ -139,7 +139,7 @@ def test_kerberos_user_sudo_wrong_password(ipa_user, user_shell):
             user_shell.expect("Sorry, try again.")
 
 
-def test_krb_user_sudo_correct_password_sc_required_no_sc(ipa_user, user_shell):
+def test_krb_user_sudo_correct_password_sc_required_no_sc(ipa_user, user_shell, allow_sudo_commands):
     with Authselect(required=True, sudo=True):
         with ipa_user.card(insert=True) as sc:
             output = pexpect.run("ls /", encoding="utf-8")

--- a/fixtures.py
+++ b/fixtures.py
@@ -1,7 +1,9 @@
 import pexpect
 import pytest
 import sys
+import logging
 
+from SCAutolib import run
 from SCAutolib.models.file import SSSDConf
 from SCAutolib.utils import user_factory
 
@@ -21,6 +23,24 @@ def root_shell():
     shell.logfile = sys.stdout
     return shell
 
+@pytest.fixture(scope="function")
+def allow_sudo_commands(ipa_user):
+    """
+    Modifying the IPA server's sudo rules to allow the test user to 
+    run sudo commands and restore the original state afterward.
+    """
+    logger = logging.getLogger()
+
+    run('ipa sudorule-add allow_sudo --hostcat=all --runasusercat=all --runasgroupcat=all --cmdcat=all'.split())
+    run(f'ipa sudorule-add-user allow_sudo --user {ipa_user.username}'.split())
+    run("systemctl restart sssd".split(), sleep = 5)
+    logger.debug("Checking that the sudo rule has been added (following command should succeed)")
+    run('ipa sudorule-show allow_sudo'.split())
+    yield # running the test's code
+    run('ipa sudorule-del allow_sudo'.split())
+    run("systemctl restart sssd".split(), sleep = 5)
+    logger.debug("Checking that the sudo rule has been removed (following command should exit with status 2)")
+    run('ipa sudorule-show allow_sudo'.split(), return_code = [2])
 
 @pytest.fixture(scope="session")
 def root_user():


### PR DESCRIPTION
This test was never working because the allowed sudo commands needed to be added to IPA server. With this commit we fix this issue by creating a new fixture that allows all commands with sudo for the tested user.