### PR TITLE
SCAutolib V3 compatibility fix

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,16 @@
+name: Codespell
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: codespell-project/actions-codespell@master
+        with:
+          ignore_words_file: .github/codespell_ignore_words.txt

--- a/Graphical/local-user-graphical-login.py
+++ b/Graphical/local-user-graphical-login.py
@@ -2,7 +2,7 @@
 This module contains tests for logging into GUI using GDM.
 Most of the tests are parametrized to test both
 optional and required smart card in authselect.
-Lock-on-removal option is not set as it is irelevent for present tests.
+Lock-on-removal option is not set as it is irrelevant for present tests.
 The tests within the module try logging in both using password and
 smart card with PIN. Both wrong password and wrong PIN are tested too.
 All tests depend on SCAutolib GUI module.

--- a/Graphical/local-user-lock-on-removal.py
+++ b/Graphical/local-user-lock-on-removal.py
@@ -136,7 +136,7 @@ def test_lockscreen_password(local_user, lock_on_removal):
         B. GDM starts and user logs in successfully
         C. Nothing happens
         D. The screen is locked
-        E. Screen is unlocked succesfully
+        E. Screen is unlocked successfully
     """
     with (
         Authselect(required=False, lock_on_removal=lock_on_removal),

--- a/Sanity/test_certs.py
+++ b/Sanity/test_certs.py
@@ -31,7 +31,8 @@ def test_wrong_issuer_cert(local_user, sssd_db, user_shell, tmp_path):
 
     sssd_db.backup()
     sssd_db.path.unlink()
-    local_ca_factory(tmp_path.joinpath("ca"))
+    local_ca_factory(path = tmp_path.joinpath("ca"),
+                     force = True, create = True)
     run(['restorecon', "-v", "/etc/sssd/pki/sssd_auth_ca_db.pem"])
 
     with Authselect():

--- a/Sanity/test_sssd_conf.py
+++ b/Sanity/test_sssd_conf.py
@@ -95,9 +95,9 @@ def test_su_login_p11_uri_user_mismatch(user, uri, auth_stat, sssd):
         8. Open GDM login screen
         9. Insert card into the reader
     Expected result:
-        User is either prompted to enter password and authenticates succesfully
-        without SC or authentication fails depending on selected authselect
-        profile.
+        User is either prompted to enter password and authenticates
+        successfully without SC or authentication fails depending on selected
+        authselect profile.
     """
     with sssd(section="pam", key="p11_uri", value=uri) as sssd_conf:
         run(["ls", "-l", "/etc/sssd/sssd.conf"])

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 import logging
 
-from SCAutolib.utils import user_factory, ipa_factory
+from SCAutolib.utils import user_factory, ipa_factory, token_factory, \
+    local_ca_factory
 from fixtures import *
 from pathlib import Path
 
@@ -16,11 +17,11 @@ def load_tokens(user, token_list):
     log.info("Loading tokens")
     for index, token in enumerate(token_list):
          log.debug("Loading %s. token", index)
-         setattr(user, f"card_{index}", token_factory(token))
+         setattr(user, f"card_{index}", token_factory(token, update_sssd = True))
          log.debug(f"Token %s is loaded", index)
 
 
-def update_ca(user, token_lit):
+def update_ca(user, token_list):
     log.info("Loading local CA")
     for index, token in enumerate(token_list):
         card_name = f"card_{index}"
@@ -51,18 +52,29 @@ def pytest_configure(config):
         ipa_user = user_factory(
             config.getoption("ipa_username"),
             ipa_server=ipa_server)
-        assert not ipa_user.local
+        assert ipa_user.user_type == "ipa"
         log.debug("IPA user is loaded")
         load_tokens(ipa_user, tokens)
+        ipa_user.card = ipa_user.card_0
         ipa_user.pin = ipa_user.card.pin
     if user_type in ["local", "all"]:
         log.debug("Loading local user")
         local_user = user_factory(config.getoption(
             "local_username"))
-        assert local_user.local
+        assert local_user.user_type == "local"
         log.debug("Local user is loaded")
         load_tokens(local_user, tokens)
+        # backwards compatibility fix. Older tests expected one virtual card
+        # as attribute of user - i.e. user.card and approached card this way.
+        # As of now we expect user can have multiple cards, they are marked
+        # user.card_0, user.card_1, ... however, for backwards compatibility,
+        # we need to provide user.card:
+        local_user.card = local_user.card_0
+
+        # pin used to be user attribute. as we can currently have multiple cards
+        # pin was moved to card. For backwards compatibility:
         local_user.pin = local_user.card.pin
+
         update_ca(local_user, tokens)
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -2,19 +2,48 @@ import logging
 
 from SCAutolib.utils import user_factory, ipa_factory
 from fixtures import *
+from pathlib import Path
 
 log = logging.getLogger("PyTest")
 log.setLevel(logging.DEBUG)
 ipa_user = None
 ipa_server = None
 local_user = None
+tokens = None
+
+
+def load_tokens(user, tokenlist):
+    log.info("Loading tokens")
+    user.card = token_factory(tokenlist[0])
+    log.debug(f"Token {tokenlist[0]} is loaded")
+    if len(tokenlist) > 1:
+        log.debug(f"Loading 2nd token: {tokenlist[1]}")
+        user.card_2 = token_factory(tokenlist[1])
+        log.debug(f"Token {tokenlist[1]} is loaded")
+    else:
+        log.debug("2nd token not defined")
+
+
+def load_ca(user):
+    log.info("Loading local CA")
+    ca = local_ca_factory(card=user.card)
+    assert Path.is_file(ca._ca_pki_db)
+    log.debug("Local CA is loaded")
+    return ca
 
 
 def pytest_configure(config):
     global ipa_user
     global ipa_server
     global local_user
+    global tokens
     user_type = config.getoption("user_type")
+    tokens = config.getoption("tokens")
+
+    # workaround to set default token as parser.addoption defining tokens
+    # is a list that needs to be empty by default
+    if not tokens:
+        tokens = ["virt-card-1"]
 
     if user_type in ["ipa", "all"]:
         log.debug("Loading IPA client")
@@ -26,12 +55,18 @@ def pytest_configure(config):
             ipa_server=ipa_server)
         assert not ipa_user.local
         log.debug("IPA user is loaded")
+        load_tokens(ipa_user, tokens)
+        ipa_user.pin = ipa_user.card.pin
     if user_type in ["local", "all"]:
         log.debug("Loading local user")
         local_user = user_factory(config.getoption(
             "local_username"))
         assert local_user.local
         log.debug("Local user is loaded")
+        load_tokens(local_user, tokens)
+        local_user.pin = local_user.card.pin
+        ca = load_ca(local_user)
+        ca.update_ca_db()
 
 
 def pytest_addoption(parser):
@@ -60,6 +95,13 @@ def pytest_addoption(parser):
         help="Type of user to be used in tests",
         choices=['local', 'ipa', 'all']
     )
+    parser.addoption(
+        "--with-tokens",
+        action="append",
+        default=[],
+        dest="tokens",
+        help="List of tokens to be prepared"
+    )
 
 
 def pytest_generate_tests(metafunc):
@@ -70,17 +112,17 @@ def pytest_generate_tests(metafunc):
     we want to test.
 
     For example, if we want to execute the test only with local user, we
-    need to se `--with-user-type local` in pytest command. Defualt name for
+    need to se `--with-user-type local` in pytest command. Default name for
     local user is "local-user". If the system is configured to a user with
     different name, set this name with `--local-username NAME` option.
     Similar options are available for IPA user. If we want to test with both,
     use `--with-user-type all`. This would set 'user' argument to both local
-    and IPA user using names specified by `--local-username` and `--ipa-username`
-    (or default names if not specified).
+    and IPA user using names specified by `--local-username` and
+    `--ipa-username` (or default names if not specified).
 
-    To avoid execuing test that are not relevant for the user type (e.g. test
-    that is relevant only for local user), this test has to specify expicitly
-    user type by adding `local_user` argmunet inseted of `user` argument.
+    To avoid executing test that are not relevant for the user type (e.g. test
+    that is relevant only for local user), this test has to specify explicitly
+    user type by adding `local_user` argument instead of `user` argument.
     Similar is true for `ipa_user` argument.
     """
     user_type = metafunc.config.getoption("user_type")
@@ -98,3 +140,5 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("local_user", [local_user])
     if "ipa_server" in metafunc.fixturenames:
         metafunc.parametrize("ipa_server", [ipa_server])
+    if "tokens" in metafunc.fixturenames:
+        metafunc.parametrize("tokens", [tokens])


### PR DESCRIPTION
Conftest takes care of loading user and card objects. It has to be updated due to changes in SCAutolib, mainly:
- Card object is no longer bind to user object - it's independent (The idea is that multiple card objects for both physical and virtual cards will be created by SCAutolib and any of them can be loaded for testing)
- Some attributes (as PIN) were moved from user to card objects
- SCAutolib supports multiple card objects and consequently correct CA certs need to be placed to CA database base on loaded card object

**Note**: SCAutolib-V3 is not yet finished. It is expected that there will be further changes in conftest.py. This initial commit outlines rough idea of changes in SC-tests for purposes of early review.