### PR TITLE
removed test_krb_user_ldap_mapping, fixing issued with V3 adoption and add --keep-sssd flag

### DIFF
--- a/Sanity/test_certs.py
+++ b/Sanity/test_certs.py
@@ -32,7 +32,8 @@ def test_wrong_issuer_cert(local_user, sssd_db, user_shell, tmp_path):
     sssd_db.backup()
     sssd_db.path.unlink()
 
-    ca_factory(path = tmp_path.joinpath("ca"),
+    run(['mkdir', tmp_path.joinpath("ca")])
+    ca_factory(path=tmp_path.joinpath("ca"), create=True)
     run(['restorecon', "-v", "/etc/sssd/pki/sssd_auth_ca_db.pem"])
 
     with Authselect():
@@ -44,4 +45,5 @@ def test_wrong_issuer_cert(local_user, sssd_db, user_shell, tmp_path):
             user_shell.expect_exact(local_user.username)
 
     sssd_db.restore()
+    run(['rm', "-rf", tmp_path.joinpath("ca")])
     run(['restorecon', "-v", "/etc/sssd/pki/sssd_auth_ca_db.pem"])

--- a/Sanity/test_smart_card_detection.py
+++ b/Sanity/test_smart_card_detection.py
@@ -1,5 +1,6 @@
 import pytest
-
+from time import sleep
+import pexpect
 
 def test_modutil_token_info(local_user, root_shell):
     """Check that p11-kit module shows smart card information with modutil
@@ -17,7 +18,7 @@ def test_pam_services_config(local_user, root_shell, sssd):
     works as expected for smart card authentication.
     GitHub issue: https://github.com/SSSD/sssd/issues/3967"""
     with open("/etc/pam.d/pam_cert_service", "w") as f:
-        f.write("auth\trequired\tpam_sss.so require_cert_auth")
+        f.write("auth\trequired\tpam_sss.so require_cert_auth\n")
     with sssd(section="pam", key="pam_p11_allowed_services", value="-su") as sssd_conf:
         with local_user.card(insert=False) as sc:
             cmd = "sssctl user-checks -a auth -s pam_cert_service " \

--- a/Sanity/test_sssd_conf.py
+++ b/Sanity/test_sssd_conf.py
@@ -136,12 +136,13 @@ def test_matchrule_defined_for_other_user(local_user, sssd, user_shell):
               value="<SUBJECT>.*CN=testuser.*") as sssd_file:
         # FIXME: this section should be replaced with library call for removing
         #  the section as soon as this functionality is implemented
-        with sssd_file.path.open("r+") as sources:
-            sourcesdata = sources.read()
-            sourcesdata = sourcesdata.replace(
+        with sssd_file.path.open("r") as fp:
+            new_context = fp.read()
+            new_context = new_context.replace(
                 f'[certmap/shadowutils/{local_user.username}]',
                 '[certmap/shadowutils/testuser]')
-            sources.write(sourcesdata)
+        with sssd_file.path.open("w") as fp:
+            fp.write(new_context)
         run(["systemctl", "restart", "sssd"])
 
         with Authselect(required=False), local_user.card(insert=True):


### PR DESCRIPTION
The test was removed for several reasons:
1) The test was never really working. The only reason it was passing was
   because of sssd caching.
2) The test in order to work needs a lot of extra parameters in sssd
   configuration and there is neither the knowledge nor the time to
   invest in learning it.
3) The LDAP mapping is not really used in our days and we believe that
   the case the test is testing is very rare.

Fix small errors for the tests to be compatible with V3:
1) Sanity/test_smart_card_detection.py::test_pam_services_config: added
   new line at the end on /etc/pam.d/pam_cert_service
2) Sanity/test_sssd_conf.py::test_matchrule_defined_for_other_user: fix
   the way it replaces certmap/shadowutils section
3) Sanity/test_certs.py::test_wrong_issuer_cert: Fixed typo 

add --keep-sssd flag 