### PR TITLE
test_local_user_passwd.py: change expected line for later OS

### DIFF
--- a/Graphical/local-user-graphical-login.py
+++ b/Graphical/local-user-graphical-login.py
@@ -186,7 +186,7 @@ def test_insert_card_prompt(local_user, lock_on_removal):
           Authselect(required=True, lock_on_removal=lock_on_removal),
           local_user.card(insert=False) as card):
         try:
-            gui.assert_text('insert')
+            gui.assert_text('insert', timeout=20)
         except Exception:
             gui.click_on(local_user.username)
 

--- a/Local-user/test_local_user_passwd.py
+++ b/Local-user/test_local_user_passwd.py
@@ -1,6 +1,7 @@
 import pytest
 
 from SCAutolib.models.authselect import Authselect
+from SCAutolib.isDistro import isDistro
 
 
 @pytest.mark.parametrize(
@@ -45,4 +46,7 @@ def test_change_local_user_passwd(local_user, user_shell, required, lock_on_remo
             user_shell.sendline(cmd)
             user_shell.expect_exact(f"PIN for {local_user.username}:")
             user_shell.sendline(local_user.pin)
-            user_shell.expect_exact(f"Changing password for user {local_user.username}.")
+            if isDistro(['rhel', 'centos'], '>=10') or isDistro('fedora', '>=40'):
+                user_shell.expect_exact(f"Current password")
+            else:
+                user_shell.expect_exact(f"Changing password for user {local_user.username}.")

--- a/Sanity/test_ttylogin.py
+++ b/Sanity/test_ttylogin.py
@@ -14,6 +14,7 @@ import pexpect
 import pytest
 
 from SCAutolib.models.authselect import Authselect
+from SCAutolib.isDistro import isDistro
 
 
 def login_shell_factory(username):
@@ -304,7 +305,10 @@ def test_login_local_user_passwd(user, required, lock_on_removal):
             login_shell.sendline(user.pin)
             login_shell.expect([user.username])
             login_shell.sendline("passwd")
-            login_shell.expect_exact(f"Changing password for user {user.username}.")
+            if isDistro(['rhel', 'centos'], '>=10') or isDistro('fedora', '>=40'):
+                login_shell.expect_exact(f"Current password")
+            else:
+                login_shell.expect_exact(f"Changing password for user {user.username}.")
 
 @pytest.mark.parametrize(
     "required,lock_on_removal", [(True, True), (True, False), (False, True), (False, False),]


### PR DESCRIPTION
For the changes of passwd to Shadow Utils in RHEL-10, CentOS 10 and fedora 40 there is no changing password message printed so the test fails.